### PR TITLE
marks verified user as authenticated maintain admin role

### DIFF
--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -171,7 +171,8 @@ class UserService:
         if user and user.verification_token == token:
             user.email_verified = True
             user.verification_token = None  # Clear the token once used
-            user.role = UserRole.AUTHENTICATED
+            if user.role == UserRole.ANONYMOUS:
+                user.role = UserRole.AUTHENTICATED
             session.add(user)
             await session.commit()
             return True


### PR DESCRIPTION
- Updated the test_email_verification_with_stale_token to reflect the expected behavior of handling expired tokens based on current business logic.
- Corrected attribute names in the test_failure_in_user_deletion to match the User model's attributes.
- Ensured all test configurations are aligned with the actual database session operations, replacing mock methods with actual commit calls.
- Changed John Doe "AUTHENTICATED" to "ADMIN"
